### PR TITLE
make op as leader when signing va_reg msg

### DIFF
--- a/src/validation/generic_operator_committee.rs
+++ b/src/validation/generic_operator_committee.rs
@@ -17,6 +17,7 @@ pub trait TOperatorCommittee : Send {
     async fn consensus(&self, msg: Hash256) -> Result<(), DvfError>;
     async fn sign(&self, msg: Hash256) -> Result<(Signature, Vec<u64>), DvfError>;
     async fn get_leader(&self, nonce: u64) -> u64;
+    async fn get_op_pos(&self, op_id: u64) -> usize;
     fn get_validator_pk(&self) -> String;
     fn threshold(&self) -> usize;
 }
@@ -58,6 +59,10 @@ where
 
     pub fn get_validator_pk(&self) -> String {
         self.cmt.get_validator_pk()
+    }
+
+    pub fn get_op_pos(&self, op_id: u64) -> usize {
+        self.cmt.get_op_pos(op_id)
     }
 }
 

--- a/src/validation/impls/hotstuff.rs
+++ b/src/validation/impls/hotstuff.rs
@@ -100,6 +100,13 @@ impl TOperatorCommittee for HotstuffOperatorCommittee {
         ids[select_order as usize]
     }
 
+    async fn get_op_pos(&self, op_id: u64) -> usize {
+        let operators = self.operators.read().await;
+        let mut ids : Vec<u64> = operators.keys().map(|k| *k).collect();
+        ids.sort();
+        ids.iter().position(|&id| id == op_id).unwrap()
+    }
+
     async fn consensus(&self, msg: Hash256) -> Result<(), DvfError> {
         let notify = {
             let mut notes = self.consensus_notifications.write().await; 

--- a/src/validation/signing_method.rs
+++ b/src/validation/signing_method.rs
@@ -167,7 +167,7 @@ impl SigningMethod {
         signing_root: Hash256,
         executor: &TaskExecutor,
         fork_info: Option<ForkInfo>,
-        signing_epoch: Epoch,
+        mut signing_epoch: Epoch,
         spec: &ChainSpec,
     ) -> Result<Signature, Error> {
 
@@ -299,7 +299,9 @@ impl SigningMethod {
                     SignableMessage::SignedContributionAndProof(_) => {
                         (Slot::new(0 as u64), "CONTRIB", true)
                     }
-                    SignableMessage::ValidatorRegistration(_) => {
+                    SignableMessage::ValidatorRegistration(_) => {  
+                        let op_pos = dvf_signer.operator_committee.get_op_pos(dvf_signer.operator_id);
+                        signing_epoch = Epoch::new(op_pos as u64);
                         (Slot::new(0 as u64), "VA_REG", true)
                     }
                 };


### PR DESCRIPTION
在开启mev后，需要op committee定期签名ValidatorRegistration message。但默认传入的epoch是0，导致如果单个节点开启mev特性时，会报not leader的错。新增的代码使得在处理签名ValidatorRegistration msg时，op总会是leader。但如果四个op都开启了mev特性，会让每个op都作为leader发起签名，需要调试观察多次到mev builder注册是否会有问题，待观察